### PR TITLE
Update link to english version of PQC Migration Handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Unzip the downloaded file and inside it run the command ```npm install``` to ins
 
 ## Background of the project
 
-The project is a continuation of the [PQC Migration Handbook](https://publications.tno.nl/publication/34643387/XTdELY16/TNO-2024-pqc-ne.pdf), which offers advice and concrete steps for organisations to mitigate the risk of quantum computers to cryptography. It goes into depth on the entire migration process, and covers more than the choice of algorithms. For this reason, we recommend using both the PQC Migration Handbook and the PQChoiceAssistant to get the best results for your organisation.
+The project is a continuation of the [PQC Migration Handbook](https://publications.tno.nl/publication/34643386/fXcPVHsX/TNO-2024-pqc-en.pdf), which offers advice and concrete steps for organisations to mitigate the risk of quantum computers to cryptography. It goes into depth on the entire migration process, and covers more than the choice of algorithms. For this reason, we recommend using both the PQC Migration Handbook and the PQChoiceAssistant to get the best results for your organisation.
 
 The research and tool development were performed by [TNO](https://www.tno.nl/) and [CWI](https://www.cwi.nl/). This process was supported by input from [AIVD](https://www.aivd.nl/), [Compumatica](https://www.compumatica.com/), [Fox Crypto](https://www.fox-it.com/nl/fox-crypto/), [NXP](https://www.nxp.com/) and [Technolution](https://www.technolution.com/).
 


### PR DESCRIPTION
I noticed that the `README.md` linked to the Dutch language version of TNO's *The PQC Migration
Handbook*. This PR fixes that by linking to the English language version. Easier for English reading consumers of the project and README so that they're not surprised by a PDF in a language they can't read.